### PR TITLE
feat: add HTTP/SOCKS5 proxy support for all network requests

### DIFF
--- a/electron/ipc/mcp-client.ts
+++ b/electron/ipc/mcp-client.ts
@@ -12,6 +12,7 @@
 // result's text content is returned to the caller for tag parsing.
 
 import axios from "axios";
+import { getAxiosConfig } from "./nai";
 import { spawn } from "child_process";
 import { EventEmitter } from "events";
 
@@ -111,7 +112,7 @@ function makePost(url: string, headers: Record<string, string>, getSid: () => st
     const h = { ...headers };
     const sid = getSid();
     if (sid) h["Mcp-Session-Id"] = sid;
-    const resp = await axios.post(url, body, {
+    const resp = await axios.post(url, body, { ...await getAxiosConfig(),
       headers: h,
       timeout: 20_000,
       responseType: "text",
@@ -195,7 +196,7 @@ async function callSse(
   if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
 
   // Open the SSE stream; the server's first "endpoint" event tells us where to POST.
-  const streamResp = await axios.get(url, {
+  const streamResp = await axios.get(url, { ...await getAxiosConfig(),
     headers: { ...headers, Accept: "text/event-stream" },
     responseType: "stream",
     timeout: 0,
@@ -259,7 +260,7 @@ async function callSse(
         });
       }
       try {
-        await axios.post(postUrl, body, { headers: { ...headers, "Content-Type": "application/json" }, timeout: 20_000 });
+        await axios.post(postUrl, body, { ...await getAxiosConfig(), headers: { ...headers, "Content-Type": "application/json" }, timeout: 20_000 });
         if (expectId === undefined) resolve(null);
       } catch (e) {
         if (timer) clearTimeout(timer);

--- a/electron/ipc/nai.ts
+++ b/electron/ipc/nai.ts
@@ -1,5 +1,7 @@
 import { dialog } from "electron";
 import axios from "axios";
+import { HttpsProxyAgent } from "https-proxy-agent";
+import { createRequire } from "node:module";
 import JSZip from "jszip";
 import crypto from "crypto";
 import fs from "fs/promises";
@@ -50,6 +52,41 @@ function tierName(tier?: number) {
   return tier === 3 ? "Opus" : tier === 2 ? "Scroll" : tier === 1 ? "Tablet" : tier === 0 ? "Paper" : "未知";
 }
 
+interface SocksProxyAgentLike { new (url: string): any; }
+let _SocksProxyAgent: SocksProxyAgentLike | null = null;
+function getSocksAgentClass(): SocksProxyAgentLike | null {
+  if (_SocksProxyAgent) return _SocksProxyAgent;
+  try {
+    const req = createRequire(__filename);
+    _SocksProxyAgent = req("socks-proxy-agent").SocksProxyAgent;
+    return _SocksProxyAgent;
+  } catch (e: any) {
+    console.error("[proxy] Failed to load socks-proxy-agent:", e?.message ?? e);
+    return null;
+  }
+}
+
+export async function getAxiosConfig(): Promise<{ httpsAgent?: HttpsProxyAgent<string>; httpAgent?: HttpsProxyAgent<string> }> {
+  const raw = getSettings().proxyUrl?.trim();
+  if (!raw) return {};
+  // Auto-prepend http:// if no protocol
+  const proxyUrl = /^https?:\/\/|^socks/i.test(raw) ? raw : `http://${raw}`;
+  const isSocks = /^socks/i.test(proxyUrl);
+  try {
+    if (isSocks) {
+      const SocksAgent = getSocksAgentClass();
+      if (!SocksAgent) return {};
+      const agent = new SocksAgent(proxyUrl) as unknown as HttpsProxyAgent<string>;
+      return { httpsAgent: agent, httpAgent: agent };
+    }
+    const agent = new HttpsProxyAgent(proxyUrl);
+    return { httpsAgent: agent, httpAgent: agent };
+  } catch (e: any) {
+    console.error("[proxy] Failed to create proxy agent:", e?.message ?? e);
+    return {};
+  }
+}
+
 function readNumber(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isFinite(value)) return Math.round(value);
   if (typeof value === "string") {
@@ -92,7 +129,7 @@ function parseAccount(data: any): Omit<AccountSummary, "hasToken"> {
 async function fetchAccount(token: string): Promise<Omit<AccountSummary, "hasToken">> {
   const settings = getSettings();
   const apiBaseUrl = normalizeBaseUrl(settings.apiBaseUrl, "https://api.novelai.net");
-  const res = await axios.get(`${apiBaseUrl}/user/data`, {
+  const res = await axios.get(`${apiBaseUrl}/user/data`, { ...await getAxiosConfig(), 
     headers: { Authorization: `Bearer ${token}` },
     timeout: 15_000,
   });
@@ -108,7 +145,7 @@ export async function verifyToken(token: string): Promise<TokenStatus> {
   try {
     const settings = getSettings();
     const apiBaseUrl = normalizeBaseUrl(settings.apiBaseUrl, "https://api.novelai.net");
-    await axios.get(`${apiBaseUrl}/user/information`, {
+    await axios.get(`${apiBaseUrl}/user/information`, { ...await getAxiosConfig(), 
       headers: { Authorization: `Bearer ${normalized}` },
       timeout: 15_000,
     });
@@ -323,7 +360,7 @@ async function prepareExtras(params: GenerateParams, extras?: GenerateExtras): P
     extras.vibeImages.map(async (vibe) => {
       try {
         const res = await requestWithRetry(
-          () =>
+          async () =>
             axios.post(
               `${imageBaseUrl}/ai/encode-vibe`,
               {
@@ -331,7 +368,7 @@ async function prepareExtras(params: GenerateParams, extras?: GenerateExtras): P
                 information_extracted: vibe.infoExtracted,
                 model: params.model,
               },
-              {
+              { ...await getAxiosConfig(),
                 headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
                 responseType: "arraybuffer",
                 timeout: 60_000,
@@ -598,8 +635,8 @@ async function postGenerateImage(payload: ReturnType<typeof buildPayload>) {
   const settings = getSettings();
   const imageBaseUrl = normalizeBaseUrl(settings.imageBaseUrl, "https://image.novelai.net");
   const res = await requestWithRetry(
-    () =>
-      axios.post(`${imageBaseUrl}/ai/generate-image`, payload, {
+    async () =>
+      axios.post(`${imageBaseUrl}/ai/generate-image`, payload, { ...await getAxiosConfig(), 
         headers: {
           Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
@@ -669,7 +706,7 @@ async function callVisionApi(
   };
 
   try {
-    const resp = await axios.post(`${base}/chat/completions`, body, {
+    const resp = await axios.post(`${base}/chat/completions`, body, { ...await getAxiosConfig(), 
       headers: { Authorization: `Bearer ${visionApiKey}`, "Content-Type": "application/json" },
       timeout: 60_000,
     });
@@ -710,7 +747,7 @@ async function callConvertApi(
   };
 
   try {
-    const resp = await axios.post(`${base}/chat/completions`, body, {
+    const resp = await axios.post(`${base}/chat/completions`, body, { ...await getAxiosConfig(), 
       headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
       timeout: 60_000,
     });
@@ -736,7 +773,7 @@ export async function listAiModels(kind: "reverse" | "convert"): Promise<AiModel
 
   try {
     const base = apiUrl.replace(/\/+$/, "");
-    const resp = await axios.get(`${base}/models`, {
+    const resp = await axios.get(`${base}/models`, { ...await getAxiosConfig(), 
       headers: { Authorization: `Bearer ${apiKey}` },
       timeout: 20_000,
     });
@@ -868,11 +905,11 @@ async function queryTagServer(query: string, limit = 12): Promise<TagSuggestion[
   const headers: Record<string, string> = {};
   if (settings.tagServerApiKey.trim()) headers.Authorization = `Bearer ${settings.tagServerApiKey.trim()}`;
 
-  const attempts = [
-    () => axios.get(`${base}/search`, { params: { q: query, query, limit }, headers, timeout: 8_000 }),
-    () => axios.get(`${base}/tags`, { params: { q: query, query, limit }, headers, timeout: 8_000 }),
-    () => axios.post(`${base}/search`, { query, limit }, { headers, timeout: 8_000 }),
-    () =>
+  const attempts: Array<() => Promise<any>> = [
+    async () => axios.get(`${base}/search`, { ...await getAxiosConfig(),  params: { q: query, query, limit }, headers, timeout: 8_000 }),
+    async () => axios.get(`${base}/tags`, { ...await getAxiosConfig(),  params: { q: query, query, limit }, headers, timeout: 8_000 }),
+    async () => axios.post(`${base}/search`, { query, limit }, { ...await getAxiosConfig(), headers, timeout: 8_000 }),
+    async () =>
       axios.post(
         base,
         {
@@ -881,7 +918,7 @@ async function queryTagServer(query: string, limit = 12): Promise<TagSuggestion[
           method: "tools/call",
           params: { name: "search_tags", arguments: { query, limit } },
         },
-        { headers: { ...headers, "Content-Type": "application/json" }, timeout: 8_000 },
+        { ...await getAxiosConfig(), headers: { ...headers, "Content-Type": "application/json" }, timeout: 8_000 },
       ),
   ];
 
@@ -1203,7 +1240,7 @@ export async function upscaleImg(scale: UpscaleScale): Promise<SingleImageResult
     // returns a ZIP archive (same as generate-image), not a raw PNG.
     const apiBaseUrl = normalizeBaseUrl(settings.apiBaseUrl, "https://api.novelai.net");
     const res = await requestWithRetry(
-      () =>
+      async () =>
         axios.post(
           `${apiBaseUrl}/ai/upscale`,
           {
@@ -1212,7 +1249,7 @@ export async function upscaleImg(scale: UpscaleScale): Promise<SingleImageResult
             height: image.height,
             scale,
           },
-          {
+          { ...await getAxiosConfig(),
             headers: {
               Authorization: `Bearer ${token}`,
               "Content-Type": "application/json",
@@ -1296,7 +1333,7 @@ export async function augmentImg(tool: DirectorTool, options: AugmentOptions): P
       payload.prompt = `${options.emotion};;${Math.min(5, Math.max(0, options.emotionLevel))}`;
     }
 
-    const res = await axios.post(`${imageBaseUrl}/ai/augment-image`, payload, {
+    const res = await axios.post(`${imageBaseUrl}/ai/augment-image`, payload, { ...await getAxiosConfig(), 
       headers: {
         Authorization: `Bearer ${token}`,
         "Content-Type": "application/json",
@@ -1384,7 +1421,7 @@ export async function suggestTags(model: string, prompt: string): Promise<TagSug
   const settings = getSettings();
   const apiBaseUrl = normalizeBaseUrl(settings.apiBaseUrl, "https://api.novelai.net");
   try {
-    const res = await axios.get(`${apiBaseUrl}/ai/generate-image/suggest-tags`, {
+    const res = await axios.get(`${apiBaseUrl}/ai/generate-image/suggest-tags`, { ...await getAxiosConfig(), 
       params: { model, prompt },
       headers: { Authorization: `Bearer ${token}` },
       timeout: 5000,
@@ -1420,7 +1457,7 @@ async function googleTranslate(
   target: string,
 ): Promise<{ ok: boolean; text?: string; error?: string }> {
   try {
-    const res = await axios.get("https://translate.googleapis.com/translate_a/single", {
+    const res = await axios.get("https://translate.googleapis.com/translate_a/single", { ...await getAxiosConfig(), 
       params: { client: "gtx", sl: "auto", tl: target, dt: "t", q: text },
       timeout: 8_000,
     });
@@ -1448,7 +1485,7 @@ async function baiduTranslate(
   const salt = String(Date.now());
   const sign = crypto.createHash("md5").update(appid + text + salt + secret).digest("hex");
   try {
-    const res = await axios.get("https://fanyi-api.baidu.com/api/trans/vip/translate", {
+    const res = await axios.get("https://fanyi-api.baidu.com/api/trans/vip/translate", { ...await getAxiosConfig(), 
       params: { q: text, from: "auto", to, appid, salt, sign },
       timeout: 8_000,
     });

--- a/electron/ipc/update.ts
+++ b/electron/ipc/update.ts
@@ -1,5 +1,6 @@
 import { app } from "electron";
 import axios from "axios";
+import { getAxiosConfig } from "./nai";
 import type { UpdateInfo } from "../../src/types";
 
 const REPO = "2786886095/novelai-image-desktop";
@@ -28,7 +29,7 @@ function compareVersions(a: string, b: string): number {
 export async function checkUpdate(): Promise<UpdateInfo> {
   const currentVersion = app.getVersion();
   try {
-    const res = await axios.get(`https://api.github.com/repos/${REPO}/releases/latest`, {
+    const res = await axios.get(`https://api.github.com/repos/${REPO}/releases/latest`, { ...await getAxiosConfig(),
       headers: { Accept: "application/vnd.github+json" },
       timeout: 10_000,
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "cross-env": "^10.1.0",
         "electron": "^42.4.0",
         "electron-builder": "^26.15.3",
+        "socks-proxy-agent": "^10.1.0",
         "typescript": "^6.0.3",
         "vite": "^8.0.16",
         "vitest": "^4.1.9",
@@ -350,7 +351,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -372,7 +372,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -380,29 +379,6 @@
       },
       "engines": {
         "node": ">=14.14"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmmirror.com/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmmirror.com/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -739,9 +715,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -759,9 +732,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -779,9 +749,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -799,9 +766,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -819,9 +783,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -839,9 +800,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1070,6 +1028,7 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2005,8 +1964,7 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-env": {
       "version": "10.1.0",
@@ -2227,6 +2185,7 @@
       "integrity": "sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.15.3",
         "builder-util": "26.15.3",
@@ -2585,7 +2544,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -2606,7 +2564,6 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -2622,7 +2579,6 @@
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -2633,7 +2589,6 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -3310,6 +3265,16 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3645,9 +3610,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3669,9 +3631,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3693,9 +3652,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3717,9 +3673,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3937,7 +3890,6 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -4222,6 +4174,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4311,7 +4264,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -4329,7 +4281,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -4444,6 +4395,7 @@
       "resolved": "https://registry.npmmirror.com/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4563,7 +4515,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -4773,6 +4724,57 @@
         "node": ">=10"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-10.1.0.tgz",
+      "integrity": "sha512-WlMj/67cEJ6MDI1OcsnjuYKDNDoyPCCYZ249kuuXPiMDw9F8PXkVaQ7YWu3siTydfQ/4BEZcvGzu+aYvz7dDCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/agent-base": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmmirror.com/source-map/-/source-map-0.6.1.tgz",
@@ -4938,7 +4940,6 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -5173,6 +5174,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "jszip": "^3.10.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
+    "socks-proxy-agent": "^10.1.0",
     "zustand": "^5.0.9"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2253,6 +2253,10 @@ function SettingsModal({ onClose }: { onClose: () => void }) {
                   <span>Image Endpoint（图片接口）</span>
                   <input value={settings.imageBaseUrl} onChange={(e) => void update("imageBaseUrl", e.target.value)} />
                 </label>
+                <label className="field">
+                  <span>代理地址（留空直连，HTTP 填 http://IP:端口，SOCKS5 填 socks5://IP:端口）</span>
+                  <input value={settings.proxyUrl} placeholder="socks5://127.0.0.1:10808" onChange={(e) => void update("proxyUrl", e.target.value)} />
+                </label>
               </div>
             )}
             {section === "storage" && (


### PR DESCRIPTION


## 改动说明
添加 HTTP/SOCKS5 代理支持，解决国内直连超时


## 关联 issue
#1 

## 自检清单
- [X] `npm run typecheck` 通过
- [X] `npm test` 通过
- [X] `npm run build` 通过
- [X] 涉及纯逻辑的改动补了单元测试
- [X] 未提交敏感信息（token、密钥等）

## 截图 / 录屏
就是不知道为什么 NAI居然不是走的DNS解析 而是直接IP访问 没理解
<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/8b3efbbd-a08d-46a1-bc4b-451a838e0f9f" />

<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/d8a8b968-929a-48bb-b90f-7d17ed5bc353" />

<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/fe8c2f35-31d3-4cf0-a34b-d6bd80d9c278" />

<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/9c19a29c-5c7b-49b9-99bf-a31423ac1af1" />
